### PR TITLE
Support matrix versions test on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 services:
   - mysql
 rvm:
-  - 2.2
+  - 2.2.4
   - 2.3.0
   - ruby-head
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: ruby
+cache: bundler
+sudo: false
+services:
+  - mysql
+rvm:
+  - 2.2
+  - 2.3.0
+  - ruby-head
+gemfile:
+  - gemfiles/rails_4_1.gemfile
+  - gemfiles/rails_4_2.gemfile
+  - gemfiles/rails_5_0.gemfile
+before_install: gem install bundler -v 1.11.2
+before_script:
+  - cp spec/database.yml.travis spec/database.yml
+  - mysql -e 'create database shibaraku_test;'
+script:
+  - bundle exec rspec
+matrix:
+  allow_failures:
+  # NOTE: There are unstable versions
+  - rvm: ruby-head
+  - gemfile: gemfiles/rails_5_0.gemfile

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -2,4 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 4.1.0"
 
+# NOTE: mysql2 v0.4.x will not work with Rails 4.1
+gem "mysql2", "~> 0.3.20"
+
 gemspec path: '../'

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 4.1.0"
+
+gemspec path: '../'

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 4.2.0"
+
+gemspec path: '../'

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 5.0.0.beta1"
+
+gemspec path: '../'

--- a/spec/database.yml.travis
+++ b/spec/database.yml.travis
@@ -1,0 +1,6 @@
+# ref. https://docs.travis-ci.com/user/database-setup/#MySQL
+test:
+  adapter: mysql2
+  database: shibaraku_test
+  username: travis
+  encoding: utf8


### PR DESCRIPTION
Add Travis CI setting file for matrix versions test (Ruby 2.2, 2.3 and trunk :x:  Rails 4.1, 4.2 and 5.0 beta)

This is successful with my repository.
https://travis-ci.org/sue445/shibaraku/builds/101849327