### PR TITLE
Use ActiveSupport lazy load hook to initialize ActiveRecord

### DIFF
--- a/lib/shibaraku.rb
+++ b/lib/shibaraku.rb
@@ -3,4 +3,5 @@ require "shibaraku/active_record_ext"
 
 module Shibaraku
 end
-ActiveRecord::Base.send(:include, Shibaraku::ActiveRecordExt)
+
+ActiveRecord::Base.include(Shibaraku::ActiveRecordExt)

--- a/lib/shibaraku.rb
+++ b/lib/shibaraku.rb
@@ -4,4 +4,6 @@ require "shibaraku/active_record_ext"
 module Shibaraku
 end
 
-ActiveRecord::Base.include(Shibaraku::ActiveRecordExt)
+ActiveSupport.on_load :active_record do
+  ActiveRecord::Base.include(Shibaraku::ActiveRecordExt)
+end


### PR DESCRIPTION
Fix breaking `active_record.belongs_to_required_by_default` configuration.